### PR TITLE
rate limit bug fix

### DIFF
--- a/bot_dashApp.py
+++ b/bot_dashApp.py
@@ -1,5 +1,6 @@
 ### Standard imports:
 import datetime
+import time
 
 ### Third party imports:
 import pandas as pd
@@ -39,6 +40,7 @@ def load_data(start):
         df_list.append(df)
         total_count = all_count
         count += len(df)
+        time.sleep(1)
     df = pd.concat(df_list).reset_index()
     df = df.drop_duplicates()
 


### PR DESCRIPTION
Two bug fixes here:

1. `[EAPI:Invalid nonce]`

This is the main culprit and the fix is easy @bletson. You'll need to go into your account and edit you API key. You'll then you'll need to adjust your nonce window to a large number (5000 is recommended). You can read more about it [here](https://support.kraken.com/hc/en-us/articles/360001148063-Why-am-I-getting-invalid-nonce-errors-)

![Screen Shot 2021-05-28 at 8 33 23 PM](https://user-images.githubusercontent.com/35936027/120054216-39f1b780-bff4-11eb-8181-b341334fbee3.png)

2. `['EAPI:Rate limit exceeded']`

Took the lazy fix and just threw a time out after each call to trades history. This call bumps up your rate limit by 2 compared to all other calls that only bumps it up by 1 or not at all. You can read more [here](https://support.kraken.com/hc/en-us/articles/206548367-What-are-the-API-rate-limits-)

Closes #21 